### PR TITLE
Add python-setuptools to RPM BuildRequires

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -31,3 +31,6 @@ warnerrors = true
 source-dir = doc/source
 build-dir = doc/build
 all_files = 1
+
+[bdist_rpm]
+build-requires = python-setuptools


### PR DESCRIPTION
The result of this is that `python setup.py bdist_rpm --source-only` and building the RPM via mock also works.
